### PR TITLE
fixed shodan key init

### DIFF
--- a/karma_v1
+++ b/karma_v1
@@ -20,7 +20,7 @@ api="${BASE_DIR}/.token"
 echo "${target}" | grep -E '^([a-zA-Z0-9](([a-zA-Z0-9-]){0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$' &> /dev/null
 if [[ "$?" -eq 0 ]];then
 ##
-${shodan_bin} init ${api} &> /dev/null
+${shodan_bin} init `cat ${api}` &> /dev/null
 BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 folder=${target}-$(date '-I')
 rm -rf output/${folder} > /dev/null


### PR DESCRIPTION
Shodan takes key value as inline argument, not key file. Hence, added `cat` to it use key value instead.